### PR TITLE
Fix deprecated twilio method

### DIFF
--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -3,7 +3,7 @@ class TwilioController < ApplicationController
 
   def send_text_message
     number_to_send_to = params[:user_phone]
-    @twilio.account.sms.messages.create(
+    @twilio.account.messages.create(
       from: "+1#{@twilio_phone_number}",
       to: number_to_send_to,
       body: "Hi <ENTER USER> from #{number_to_send_to}. To unlock your door. Please reply to this message."


### PR DESCRIPTION
@echenique11 @aperezmontan 

Fixed deprecated method from the Twilio API. Was working before, but was getting a notification in the heroku logs of the deprecation of the 'sms' method. (basically it's not needed anymore)
